### PR TITLE
Any% fixes

### DIFF
--- a/src/upgrades.c
+++ b/src/upgrades.c
@@ -179,25 +179,27 @@ void SetupUpgrades()
         {
         case stage_crawfish:
             lives = 0;
-            weaponAmmo[6] = 0x5C;
+            weaponAmmo[6 * 2] = 0x5C;
             break;
         case stage_catfish:
             lives = 0;
-            weaponAmmo[3] = 0x5C;
-            weaponAmmo[6] = 0x5C;
+            weaponAmmo[3 * 2] = 0x5C;
+            weaponAmmo[6 * 2] = 0x5C;
             break;
         case stage_doppler_1:
         case stage_doppler_2:
             upgrades = upgrade_vile_dead; // Vile defeated in Volt Catfish level
-            weaponAmmo[3] = 0x5C;
-            weaponAmmo[6] = 0x5C;
+            weaponAmmo[3 * 2] = 0x5C;
+            weaponAmmo[6 * 2] = 0x5C;
+            break;
         case stage_doppler_3:
         case stage_doppler_4:
-            weaponAmmo[3] = 0x5C;
-            weaponAmmo[6] = 0x5C;
+            weaponAmmo[3 * 2] = 0x5C;
+            weaponAmmo[6 * 2] = 0x5C;
             upgrades = upgrade_saber | upgrade_vile_dead | upgrade_zero_dead;
             zeroUnavailable = 1;
             bossFlags = 0x30;
+            break;
         default:
             break;
         }


### PR DESCRIPTION
- Ensure weaponAmmo indices are multiplied by 2 to get the correct weapons
- Add missing break statement for Doppler 1/2, which was causing fallthrough to Doppler 3/4 upgrades on Doppler 1/2